### PR TITLE
modifications for TYPO3 9.5

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2020-06-19 Franz Holzinger <franz@ttproducts.de>
+
+    * ready for TYPO3 9.5. TCA modifications
+
 2018-11-29 Franz Holzinger <franz@ttproducts.de>
 
     * bugfix to the hook for tt_news

--- a/ChangeLog
+++ b/ChangeLog
@@ -1,4 +1,4 @@
-2020-06-19 Franz Holzinger <franz@ttproducts.de>
+2020-06-24 Franz Holzinger <franz@ttproducts.de>
 
     * ready for TYPO3 9.5. TCA modifications
 

--- a/Classes/Api/Ajax.php
+++ b/Classes/Api/Ajax.php
@@ -110,7 +110,9 @@ class Ajax {
             list($row) = $databaseHandle->exec_SELECTgetRows('COUNT(*) AS t',
                     'tx_ratings_data', $dataWhere);
             if ($row['t'] > 0) {
-                $databaseHandle->exec_UPDATEquery('tx_ratings_data', $dataWhere,
+                $databaseHandle->exec_UPDATEquery(
+                    'tx_ratings_data',
+                    $dataWhere,
                     array(
                         'vote_count' => 'vote_count+1',
                         'rating' => 'rating+' . intval($this->rating),
@@ -118,7 +120,8 @@ class Ajax {
                     ), 'vote_count,rating');
             }
             else {
-                $databaseHandle->exec_INSERTquery('tx_ratings_data',
+                $databaseHandle->exec_INSERTquery(
+                    'tx_ratings_data',
                     array(
                         'pid' => $this->conf['storagePid'],
                         'crdate' => time(),
@@ -126,7 +129,8 @@ class Ajax {
                         'reference' => $this->ref,
                         'vote_count' => 1,
                         'rating' => $this->rating,
-                    ));
+                    )
+                );
             }
             // Call hook if ratings is updated
             if (is_array($GLOBALS['TYPO3_CONF_VARS']['EXTCONF']['ratings']['updateRatings'])) {
@@ -139,14 +143,17 @@ class Ajax {
                     GeneralUtility::callUserFunction($userFunc, $params, $this);
                 }
             }
-            $databaseHandle->exec_INSERTquery('tx_ratings_iplog',
+
+            $databaseHandle->exec_INSERTquery(
+                'tx_ratings_iplog',
                 array(
                     'pid' => $this->conf['storagePid'],
                     'crdate' => time(),
                     'tstamp' => time(),
                     'reference' => $this->ref,
                     'ip' => $api->getCurrentIp(),
-                ));
+                )
+            );
             $databaseHandle->sql_query('COMMIT');
         }
 

--- a/Configuration/TCA/Overrides/sys_template.php
+++ b/Configuration/TCA/Overrides/sys_template.php
@@ -1,0 +1,8 @@
+<?php
+defined('TYPO3_MODE') || die('Access denied.');
+
+call_user_func(function () {
+
+    \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('ratings', 'Configuration/TypoScript', 'Ratings');
+});
+

--- a/Configuration/TCA/Overrides/tt_content.php
+++ b/Configuration/TCA/Overrides/tt_content.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3_MODE') || die('Access denied.');
 
 $listType = 'ratings';
 
@@ -9,11 +9,11 @@ $GLOBALS['TCA']['tt_content']['types']['list']['subtypes_addlist'][$listType] = 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPiFlexFormValue($listType, 'FILE:EXT:ratings/Configuration/FlexForms/flexform_ds.xml');
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPlugin(
-    array(
+    [
         'LLL:EXT:ratings/Resources/Private/Language/locallang_tca.xlf:tt_content.list_type',
         $listType,
         'EXT:ratings/ext_icon.gif'
-    ),
+    ],
     'list_type',
     'ratings'
 );

--- a/Configuration/TCA/Overrides/tt_news.php
+++ b/Configuration/TCA/Overrides/tt_news.php
@@ -1,21 +1,21 @@
 <?php
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3_MODE') || die('Access denied.');
 
 // New columns
-$tempColumns = array (
-    'tx_ratings_enable' => Array (
+$tempColumns = [
+    'tx_ratings_enable' => [
         'exclude' => 1,
         'label' => 'LLL:EXT:ratings/Resources/Private/Language/locallang_tca.xlf:tt_news.tx_ratings_enable',
-        'config' => array (
+        'config' => [
             'type'     => 'check',
-            'items'    => array(
-                array('', '')
-            ),
+            'items'    => [
+                ['', '']
+            ],
             'default'  => '1'
-        )
-    ),
-);
+        ]
+    ]
+];
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addTCAcolumns('tt_news', $tempColumns, 1);
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tt_news', 'tx_ratings_enable;;;;1-1-1');
+\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addToAllTCAtypes('tt_news', 'tx_ratings_enable');
 

--- a/Configuration/TCA/Overrides/tx_ratings_data.php
+++ b/Configuration/TCA/Overrides/tx_ratings_data.php
@@ -1,8 +1,18 @@
 <?php
 defined('TYPO3_MODE') || die('Access denied.');
 
-$tx_ratings_sysconf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['ratings']);
-$tx_ratings_debug_mode_disabled = is_array($tx_ratings_sysconf) && !intval($tx_ratings_sysconf['debugMode']);
+if (
+    defined('TYPO3_version') &&
+    version_compare(TYPO3_version, '9.0.0', '>=')
+) {
+    $extensionConfiguration = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+        \TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class
+    )->get('ratings');
+} else { // before TYPO3 9
+    $extensionConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['ratings']);
+}
+
+$tx_ratings_debug_mode_disabled = is_array($extensionConfiguration) && !intval($extensionConfiguration['debugMode']);
 
 $GLOBALS['TCA']['tx_ratings_data']['ctrl']['hideTable'] = $tx_ratings_debug_mode_disabled;
 $GLOBALS['TCA']['tx_ratings_data']['ctrl']['readOnly']  = $tx_ratings_debug_mode_disabled;

--- a/Configuration/TCA/Overrides/tx_ratings_data.php
+++ b/Configuration/TCA/Overrides/tx_ratings_data.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3_MODE') || die('Access denied.');
 
 $tx_ratings_sysconf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['ratings']);
 $tx_ratings_debug_mode_disabled = is_array($tx_ratings_sysconf) && !intval($tx_ratings_sysconf['debugMode']);

--- a/Configuration/TCA/Overrides/tx_ratings_iplog.php
+++ b/Configuration/TCA/Overrides/tx_ratings_iplog.php
@@ -1,11 +1,19 @@
 <?php
 defined('TYPO3_MODE') || die('Access denied.');
 
-$tx_ratings_sysconf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['ratings']);
-$tx_ratings_debug_mode_disabled = is_array($tx_ratings_sysconf) && !intval($tx_ratings_sysconf['debugMode']);
+if (
+    defined('TYPO3_version') &&
+    version_compare(TYPO3_version, '9.0.0', '>=')
+) {
+    $extensionConfiguration = \TYPO3\CMS\Core\Utility\GeneralUtility::makeInstance(
+        \TYPO3\CMS\Core\Configuration\ExtensionConfiguration::class
+    )->get('ratings');
+} else { // before TYPO3 9
+    $extensionConfiguration = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['ratings']);
+}
+
+$tx_ratings_debug_mode_disabled = is_array($extensionConfiguration) && !intval($extensionConfiguration['debugMode']);
 
 $GLOBALS['TCA']['tx_ratings_iplog']['ctrl']['hideTable'] = $tx_ratings_debug_mode_disabled;
 $GLOBALS['TCA']['tx_ratings_iplog']['ctrl']['readOnly']  = $tx_ratings_debug_mode_disabled;
-
-
 

--- a/Configuration/TCA/Overrides/tx_ratings_iplog.php
+++ b/Configuration/TCA/Overrides/tx_ratings_iplog.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3_MODE') || die('Access denied.');
 
 $tx_ratings_sysconf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['ratings']);
 $tx_ratings_debug_mode_disabled = is_array($tx_ratings_sysconf) && !intval($tx_ratings_sysconf['debugMode']);

--- a/Configuration/TCA/tx_ratings_data.php
+++ b/Configuration/TCA/tx_ratings_data.php
@@ -21,8 +21,7 @@ $result = [
             'config' => [
                 'type' => 'input',
                 'renderType' => 'inputDateTime',
-                'dbType' => 'datetime',
-                'eval' => 'datetime',
+                'eval' => 'datetime,int',
                 'readOnly' => $tx_ratings_debug_mode_disabled,
                 'default' => 0
             ]

--- a/Configuration/TCA/tx_ratings_data.php
+++ b/Configuration/TCA/tx_ratings_data.php
@@ -1,8 +1,8 @@
 <?php
-if (!defined ('TYPO3_MODE')) die('Access denied.');
+defined('TYPO3_MODE') || die('Access denied.');
 
-$result = array (
-    'ctrl' => array (
+$result = [
+    'ctrl' => [
         'title'     => 'LLL:EXT:ratings/Resources/Private/Language/locallang_tca.xlf:tx_ratings_data',
         'label'     => 'reference',
         'tstamp'    => 'tstamp',
@@ -10,64 +10,83 @@ $result = array (
         'cruser_id' => 'cruser_id',
         'default_sortby' => 'ORDER BY crdate DESC',
         'iconfile'  =>  'EXT:ratings/Resources/Public/Icons/icon_tx_ratings_data.gif'
-    ),
-    'interface' => array (
+    ],
+    'interface' => [
         'showRecordFieldList' => 'reference,rating,vote_count'
-    ),
-    'columns' => array (
-        'reference' => array (
+    ],
+    'columns' => [
+        'crdate' => [
+            'exclude' => 1,
+            'label' => 'LLL:EXT:ratings/Resources/Private/Language/locallang_tca.xlf:tx_ratings_data.crdate',
+            'config' => [
+                'type' => 'input',
+                'renderType' => 'inputDateTime',
+                'dbType' => 'datetime',
+                'eval' => 'datetime',
+                'readOnly' => $tx_ratings_debug_mode_disabled,
+                'default' => 0
+            ]
+        ],
+        'reference' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:ratings/Resources/Private/Language/locallang_tca.xlf:tx_ratings_data.reference',
-            'config' => array (
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => '*',
                 'size' => 1,
                 'minitems' => 1,
                 'maxitems' => 1,
-            )
-        ),
-        'rating' => array (
+                'default' => ''
+            ]
+        ],
+        'rating' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:ratings/Resources/Private/Language/locallang_tca.xlf:tx_ratings_data.rating',
-            'config' => array (
+            'config' => [
                 'type' => 'input',
                 'size' => '4',
                 'max' => '4',
                 'eval' => 'int',
-                'checkbox' => '0',
-                'range' => array (
+                'range' => [
+                    'lower' => '1',
                     'upper' => '1000',
-                    'lower' => '1'
-                ),
-                'default' => 0
-            )
-        ),
-        'vote_count' => array (
+                ],
+                'default' => 0,
+                'slider' => [
+                    'step' => 10,
+                    'width' => 200,
+                ],
+            ]
+        ],
+        'vote_count' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:ratings/Resources/Private/Language/locallang_tca.xlf:tx_ratings_data.vote_count',
-            'config' => array (
+            'config' => [
                 'type' => 'input',
                 'size' => '4',
                 'max' => '4',
                 'eval' => 'int',
-                'checkbox' => '0',
-                'range' => array (
+                'range' => [
+                    'lower' => '1',
                     'upper' => '1000',
-                    'lower' => '1'
-                ),
-                'default' => 0
-            )
-        ),
-    ),
+                ],
+                'default' => 0,
+                'slider' => [
+                    'step' => 10,
+                    'width' => 200,
+                ],
+            ]
+        ],
+    ],
 
-    'types' => array (
-        '0' => array('showitem' => 'reference;;;;1-1-1, rating, vote_count')
-    ),
-    'palettes' => array (
-        '1' => array('showitem' => '')
-    )
-);
+    'types' => [
+        '0' => ['showitem' => 'crdate, reference, rating, vote_count']
+    ],
+    'palettes' => [
+        '1' => ['showitem' => '']
+    ]
+];
 
 return $result;
 

--- a/Configuration/TCA/tx_ratings_iplog.php
+++ b/Configuration/TCA/tx_ratings_iplog.php
@@ -34,8 +34,7 @@ $result = [
             'config' => [
                 'type' => 'input',
                 'renderType' => 'inputDateTime',
-                'dbType' => 'datetime',
-                'eval' => 'datetime',
+                'eval' => 'datetime,int',
                 'readOnly' => $tx_ratings_debug_mode_disabled,
                 'default' => 0
             ]

--- a/Configuration/TCA/tx_ratings_iplog.php
+++ b/Configuration/TCA/tx_ratings_iplog.php
@@ -1,8 +1,8 @@
 <?php
-if (!defined ('TYPO3_MODE')) die('Access denied.');
+defined('TYPO3_MODE') || die('Access denied.');
 
-$result = array (
-    'ctrl' => array (
+$result = [
+    'ctrl' => [
         'title'     => 'LLL:EXT:ratings/Resources/Private/Language/locallang_tca.xlf:tx_ratings_iplog',
         'label'     => 'reference',
         'tstamp'    => 'tstamp',
@@ -10,52 +10,55 @@ $result = array (
         'cruser_id' => 'cruser_id',
         'default_sortby' => 'ORDER BY crdate DESC',
         'iconfile'  =>  'EXT:ratings/Resources/Public/Icons/icon_tx_ratings_iplog.gif'
-    ),
-    'interface' => array (
+    ],
+    'interface' => [
         'showRecordFieldList' => 'reference,crdate,ip'
-    ),
-    'columns' => array (
-        'reference' => array (
+    ],
+    'columns' => [
+        'reference' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:ratings/Resources/Private/Language/locallang_tca.xlf:tx_ratings_iplog.reference',
-            'config' => array (
+            'config' => [
                 'type' => 'group',
                 'internal_type' => 'db',
                 'allowed' => '*',
                 'size' => 1,
                 'minitems' => 1,
                 'maxitems' => 1,
-            )
-        ),
-        'crdate' => array (
+                'default' => ''
+            ]
+        ],
+        'crdate' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:ratings/Resources/Private/Language/locallang_tca.xlf:tx_ratings_iplog.crdate',
-            'config' => array (
+            'config' => [
                 'type' => 'input',
-                'size' => '22',
-                'max' => '16',
+                'renderType' => 'inputDateTime',
+                'dbType' => 'datetime',
                 'eval' => 'datetime',
                 'readOnly' => $tx_ratings_debug_mode_disabled,
-            )
-        ),
-        'ip' => array (
+                'default' => 0
+            ]
+        ],
+        'ip' => [
             'exclude' => 1,
             'label' => 'LLL:EXT:ratings/Resources/Private/Language/locallang_tca.xlf:tx_ratings_iplog.ip',
-            'config' => array (
+            'config' => [
                 'type' => 'input',
                 'size' => '22',
                 'max' => '16',
                 'eval' => 'trim',
-            )
-        ),
-    ),
-    'types' => array (
-        '0' => array('showitem' => 'reference;;;;1-1-1, crdate, ip')
-    ),
-    'palettes' => array (
-        '1' => array('showitem' => '')
-    )
-);
+                'default' => ''
+            ]
+        ],
+    ],
+    'types' => [
+        '0' => ['showitem' => 'reference, crdate, ip']
+    ],
+    'palettes' => [
+        '1' => ['showitem' => '']
+    ]
+];
 
 return $result;
 

--- a/Resources/Private/Language/locallang_tca.xlf
+++ b/Resources/Private/Language/locallang_tca.xlf
@@ -6,6 +6,9 @@
 			<trans-unit id="tx_ratings_data" xml:space="preserve">
 				<source>Ratings data</source>
 			</trans-unit>
+			<trans-unit id="tx_ratings_data.crdate" xml:space="preserve">
+				<source>Firstly rated on:</source>
+			</trans-unit>
 			<trans-unit id="tx_ratings_data.reference" xml:space="preserve">
 				<source>Rated item:</source>
 			</trans-unit>

--- a/composer.json
+++ b/composer.json
@@ -18,10 +18,10 @@
     }
   ],
   "license": [
-    "GPL-2.0+"
+    "GPL-2.0-or-later"
   ],
   "require": {
-    "typo3/cms-core": ">=7.6.0,<8.7.99",
+    "typo3/cms-core": ">=7.6.0,<=9.5.99",
     "typo3-ter/div2007": ">=1.10.1"
   },
   "autoload": {
@@ -30,7 +30,7 @@
     }
   },
   "replace": {
-    "ratings": "self.version",
+    "netcreators/ratings": "self.version",
     "typo3-ter/ratings": "self.version"
   },
   "extra": {

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -8,7 +8,7 @@ $EM_CONF[$_EXTKEY] = array (
 	'title' => 'Ratings',
 	'description' => 'Modern AJAX-based ratings system. Public free support is provided only through typo3.slack.com! Contact by e-mail for commercial support.',
 	'category' => 'plugin',
-	'version' => '3.0.1',
+	'version' => '3.1.0',
 	'state' => 'beta',
 	'uploadfolder' => 0,
 	'createDirs' => '',
@@ -21,7 +21,7 @@ $EM_CONF[$_EXTKEY] = array (
 		'depends' => 
 		array (
 			'php' => '5.6.0-7.2.99',
-            'typo3' => '7.6.0-8.7.99'
+            'typo3' => '7.6.0-9.5.99'
 		),
 		'conflicts' => 
 		array (

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -20,7 +20,7 @@ $EM_CONF[$_EXTKEY] = array (
 	array (
 		'depends' => 
 		array (
-			'php' => '5.6.0-7.2.99',
+			'php' => '5.6.0-7.3.99',
             'typo3' => '7.6.0-9.5.99'
 		),
 		'conflicts' => 

--- a/ext_emconf.php
+++ b/ext_emconf.php
@@ -28,6 +28,7 @@ $EM_CONF[$_EXTKEY] = array (
 		),
 		'suggests' => 
 		array (
+            'typo3db_legacy' => '1.0.0-1.1.99',
 		),
 	),
 );

--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -1,5 +1,5 @@
 <?php
-defined('TYPO3_MODE') or die('Access denied.');
+defined('TYPO3_MODE') || die('Access denied.');
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addPItoST43('ratings', 'class.tx_ratings.php', '', 'list_type', false);
 

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -10,5 +10,3 @@ if (
     $GLOBALS['TBE_MODULES_EXT']['xMOD_db_new_content_el']['addElClasses']['Netcreators\\Ratings\\Controller\\WizardIcon'] = \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::extPath('ratings') . 'Classes/Controller/WizardIcon.php';
 }
 
-\TYPO3\CMS\Core\Utility\ExtensionManagementUtility::addStaticFile('ratings', 'Configuration/TypoScript', 'Ratings');
-

--- a/ext_tables.php
+++ b/ext_tables.php
@@ -1,5 +1,5 @@
 <?php
-if (!defined ('TYPO3_MODE')) die('Access denied.');
+defined('TYPO3_MODE') || die('Access denied.');
 
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_ratings_data');
 \TYPO3\CMS\Core\Utility\ExtensionManagementUtility::allowTableOnStandardPages('tx_ratings_iplog');

--- a/ext_tables.sql
+++ b/ext_tables.sql
@@ -7,7 +7,7 @@ CREATE TABLE tx_ratings_data (
 	tstamp int(11) DEFAULT '0' NOT NULL,
 	crdate int(11) DEFAULT '0' NOT NULL,
 	cruser_id int(11) DEFAULT '0' NOT NULL,
-	reference text NOT NULL,
+	reference text,
 	rating int(11) DEFAULT '0' NOT NULL,
 	vote_count int(11) DEFAULT '0' NOT NULL,
 
@@ -25,7 +25,7 @@ CREATE TABLE tx_ratings_iplog (
 	tstamp int(11) DEFAULT '0' NOT NULL,
 	crdate int(11) DEFAULT '0' NOT NULL,
 	cruser_id int(11) DEFAULT '0' NOT NULL,
-	reference text NOT NULL,
+	reference text,
 	ip varchar(255) DEFAULT '0' NOT NULL,
 
 	PRIMARY KEY (uid),


### PR DESCRIPTION
These modifications work for TYPO3 9.5. The old database API is still used.
